### PR TITLE
[IMP] Remove the to pay mark on an invoice when it is fully paid on in payment

### DIFF
--- a/account_invoice_select_for_payment/README.rst
+++ b/account_invoice_select_for_payment/README.rst
@@ -31,7 +31,9 @@ Account Invoice Select for Payment
 This module allows to mark invoices as "selected for payment". This can
 be done in the list view of invoices using a button in the first column
 of the view which shows the selection status. This selection persists
-until a payment is registered.
+until a payment is registered. It's also possible to choose if the
+invoice is to pay or not directly in the form viex of the invoice. When
+it's to pay, a ribbon appears.
 
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
@@ -48,7 +50,9 @@ Usage
 
 To mark an invoice as "selected for payment", click on the button before
 the Number column. This will change the state and change the way the
-button is displayed to a checked box.
+button is displayed to a checked box. It's also possible to choose if
+the invoice is to pay or not directly in the form viex of the invoice.
+When it's to pay, a ribbon appears.
 
 When done, use the search filter "Selected for payment", and select all
 the lines to give access to the Actions menu, in which you can select
@@ -78,21 +82,22 @@ Authors
 Contributors
 ------------
 
--  Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
--  Hiep Nguyen Hoang <hiepnh@trobz.com>
--  Khoi (Kien Kim) <khoikk@trobz.com>
+- Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+- Hiep Nguyen Hoang <hiepnh@trobz.com>
+- Khoi (Kien Kim) <khoikk@trobz.com>
+- Florian da Costa <florian.dacosta@akretion.com>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
--  Camptocamp
+- Camptocamp
 
 The migration of this module from 14.0 to 18.0 was financially supported
 by:
 
--  Camptocamp
+- Camptocamp
 
 Maintainers
 -----------

--- a/account_invoice_select_for_payment/models/account_move.py
+++ b/account_invoice_select_for_payment/models/account_move.py
@@ -1,13 +1,19 @@
 # Copyright 2020 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    selected_for_payment = fields.Boolean("To Pay")
+    selected_for_payment = fields.Boolean(
+        string="To Pay",
+        compute="_compute_selected_for_payment",
+        readonly=False,
+        store=True,
+        tracking=True,
+    )
 
     def action_toggle_select_for_payment(self):
         selected = self.filtered(lambda rec: rec.selected_for_payment)
@@ -16,6 +22,12 @@ class AccountMove(models.Model):
             selected.write({"selected_for_payment": False})
         if unselected:
             unselected.write({"selected_for_payment": True})
+
+    @api.depends("payment_state")
+    def _compute_selected_for_payment(self):
+        for rec in self:
+            if rec.payment_state in ("in_payment", "paid", "reversed"):
+                rec.selected_for_payment = False
 
     def action_register_payment(self):
         invoices = self.filtered(lambda inv: inv.selected_for_payment)

--- a/account_invoice_select_for_payment/readme/CONTRIBUTORS.md
+++ b/account_invoice_select_for_payment/readme/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 - Alexandre Fayolle \<<alexandre.fayolle@camptocamp.com>\>
 - Hiep Nguyen Hoang \<<hiepnh@trobz.com>\>
 - Khoi (Kien Kim) \<<khoikk@trobz.com>\>
+- Florian da Costa \<<florian.dacosta@akretion.com>\>

--- a/account_invoice_select_for_payment/readme/DESCRIPTION.md
+++ b/account_invoice_select_for_payment/readme/DESCRIPTION.md
@@ -2,3 +2,5 @@ This module allows to mark invoices as "selected for payment". This can
 be done in the list view of invoices using a button in the first column
 of the view which shows the selection status. This selection persists
 until a payment is registered.
+It's also possible to choose if the invoice is to pay or not directly in the form viex of the invoice.
+When it's to pay, a ribbon appears.

--- a/account_invoice_select_for_payment/readme/USAGE.md
+++ b/account_invoice_select_for_payment/readme/USAGE.md
@@ -1,6 +1,8 @@
 To mark an invoice as "selected for payment", click on the button before
 the Number column. This will change the state and change the way the
 button is displayed to a checked box.
+It's also possible to choose if the invoice is to pay or not directly in the form viex of the invoice.
+When it's to pay, a ribbon appears.
 
 When done, use the search filter "Selected for payment", and select all
 the lines to give access to the Actions menu, in which you can select

--- a/account_invoice_select_for_payment/static/description/index.html
+++ b/account_invoice_select_for_payment/static/description/index.html
@@ -373,7 +373,9 @@ ul.auto-toc {
 <p>This module allows to mark invoices as “selected for payment”. This can
 be done in the list view of invoices using a button in the first column
 of the view which shows the selection status. This selection persists
-until a payment is registered.</p>
+until a payment is registered. It’s also possible to choose if the
+invoice is to pay or not directly in the form viex of the invoice. When
+it’s to pay, a ribbon appears.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.
@@ -398,7 +400,9 @@ Only for development or testing purpose, do not use in production.
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
 <p>To mark an invoice as “selected for payment”, click on the button before
 the Number column. This will change the state and change the way the
-button is displayed to a checked box.</p>
+button is displayed to a checked box. It’s also possible to choose if
+the invoice is to pay or not directly in the form viex of the invoice.
+When it’s to pay, a ribbon appears.</p>
 <p>When done, use the search filter “Selected for payment”, and select all
 the lines to give access to the Actions menu, in which you can select
 “Register payment” to display the Payment wizard.</p>
@@ -427,6 +431,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Alexandre Fayolle &lt;<a class="reference external" href="mailto:alexandre.fayolle&#64;camptocamp.com">alexandre.fayolle&#64;camptocamp.com</a>&gt;</li>
 <li>Hiep Nguyen Hoang &lt;<a class="reference external" href="mailto:hiepnh&#64;trobz.com">hiepnh&#64;trobz.com</a>&gt;</li>
 <li>Khoi (Kien Kim) &lt;<a class="reference external" href="mailto:khoikk&#64;trobz.com">khoikk&#64;trobz.com</a>&gt;</li>
+<li>Florian da Costa &lt;<a class="reference external" href="mailto:florian.dacosta&#64;akretion.com">florian.dacosta&#64;akretion.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/account_invoice_select_for_payment/tests/test_account_invoice_select_for_payment.py
+++ b/account_invoice_select_for_payment/tests/test_account_invoice_select_for_payment.py
@@ -1,3 +1,4 @@
+from odoo import fields
 from odoo.tests import TransactionCase
 
 
@@ -26,7 +27,8 @@ class TestAccountMoveAndPayment(TransactionCase):
     def _create_invoice(cls, partner_id, selected_for_payment):
         invoice = cls.env["account.move"].create(
             {
-                "move_type": "out_invoice",
+                "invoice_date": fields.Date.today(),
+                "move_type": "in_invoice",
                 "partner_id": partner_id,
                 "selected_for_payment": selected_for_payment,
             }
@@ -89,3 +91,28 @@ class TestAccountMoveAndPayment(TransactionCase):
         self.env.invalidate_all()
         self.assertFalse(self.invoice_1.selected_for_payment)
         self.assertTrue(self.invoice_2.selected_for_payment)
+
+    def test_to_pay_removal_when_paid(self):
+        """Test that selected_for_payment is removed when invoice is fully paid"""
+        # create and reconcile a payment without using the register payment wizard
+        journal = self.env["account.journal"].search(
+            [("type", "=", "bank"), ("company_id", "=", self.invoice_2.company_id.id)],
+            limit=1,
+        )
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": journal.id,
+                "amount": self.invoice_2.amount_total,
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.invoice_2.partner_id.id,
+            }
+        )
+        payment.action_post()
+        _liquidity_line, payable_line, _write_off_line = payment._seek_for_lines()
+        payable_invoice_line = self.invoice_2.line_ids.filtered(
+            lambda line: line.account_id.account_type == "liability_payable"
+        )
+        self.assertTrue(self.invoice_2.selected_for_payment)
+        (payable_line | payable_invoice_line).reconcile()
+        self.assertFalse(self.invoice_2.selected_for_payment)

--- a/account_invoice_select_for_payment/views/account_move.xml
+++ b/account_invoice_select_for_payment/views/account_move.xml
@@ -1,5 +1,41 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <button name="button_draft" position="after">
+                <button
+                    name="action_toggle_select_for_payment"
+                    string="To Pay"
+                    type="object"
+                    invisible="selected_for_payment == True or payment_state not in ('not_paid', 'partial') or move_type not in ('in_invoice', 'out_refund')"
+                    class="btn-primary"
+                    style="background-color:green"
+                />
+                <button
+                    name="action_toggle_select_for_payment"
+                    string="Not To Pay"
+                    type="object"
+                    invisible="selected_for_payment == False or payment_state not in ('not_paid', 'partial') or move_type not in ('in_invoice', 'out_refund')"
+                    class="btn-primary"
+                    style="background-color:grey"
+                />
+            </button>
+            <xpath expr="//sheet/widget[5]" position="after">
+                <widget
+                    name="web_ribbon"
+                    title="To Pay"
+                    bg_color="bg-info"
+                    invisible="selected_for_payment == False or payment_state != 'not_paid' or move_type not in ('in_invoice', 'out_refund')"
+                />
+            </xpath>
+            <field name="partner_bank_id" position="after">
+                <field name="selected_for_payment" invisible="1" />
+            </field>
+        </field>
+    </record>
+
     <record id="view_invoice_tree" model="ir.ui.view">
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_invoice_tree" />
@@ -7,8 +43,9 @@
             <field name="name" position="before">
                 <field
                     name="selected_for_payment"
-                    invisible="payment_state not in ('not_paid', 'partial')"
+                    invisible="payment_state not in ('not_paid', 'partial') or move_type not in ('in_invoice', 'out_refund')"
                     widget="boolean_toggle"
+                    optional="show"
                 />
             </field>
         </field>


### PR DESCRIPTION
Presently, the module only works with the register payment button, which seems quite problematic, as it is normally not very used when the full accounting is done in Odoo.
Indeed, if you pay your invoice by wire transfer, the payment will come from your bank statement or from an `account.payment.order` for instance.

So the main change here is that the `selected_for_payment` is computed so it is removed when invoice is paid or in payment.

This PR includes other small improvement like : 
- possibility to mark the invoice as to pay from the form invoice view.
- Make it possible to hide the field on tree view, since it is probably only for some users. Also, this allow to hide it on the customer invoice view, since it mainly concerns the supplier invoices.

Last thing, I think it is very weird to remove the `selected_for_payment` mark if one user click on the register payment button but does not proceed to the payamnt (cancel it).
I would remove the override of `action_register_payment` and only rely on the computed field to remove it...
Still I did not do it in this PR because I am not sure it is ok for everybody, and I do not really have a solution for the partial payment case.

An equivalent PR actually was already proposed/approved in v14, but was never merged see : https://github.com/OCA/bank-payment/pull/1317

FYI @aleuffre @renda-dev